### PR TITLE
Add share desktop app link to drawer

### DIFF
--- a/lib/src/screens/drawer_screen/drawer_screen.dart
+++ b/lib/src/screens/drawer_screen/drawer_screen.dart
@@ -9,6 +9,7 @@ import 'package:acela/src/screens/settings/settings_screen.dart';
 import 'package:acela/src/screens/stories/stories_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
 
 class DrawerScreen extends StatelessWidget {
   const DrawerScreen({Key? key}) : super(key: key);
@@ -170,6 +171,17 @@ class DrawerScreen extends StatelessWidget {
         Navigator.pop(context);
         Navigator.of(context)
             .push(MaterialPageRoute(builder: (c) => const AboutHomeScreen()));
+      },
+    );
+  }
+
+
+  Widget _desktopApp() {
+    return ListTile(
+      leading: const Icon(Icons.download),
+      title: const Text("Desktop App"),
+      onTap: () {
+        Share.share('Download 3Speak on desktop at https://github.com/spknetwork/3Speak-app');
       },
     );
   }

--- a/lib/src/screens/drawer_screen/drawer_screen.dart
+++ b/lib/src/screens/drawer_screen/drawer_screen.dart
@@ -224,6 +224,7 @@ class DrawerScreen extends StatelessWidget {
         _divider(),
         _shorts(context),
         _divider(),
+        _desktopApp(),
         _settings(context),
         _divider(),
         user.username == null ? _login(context) : _myAccount(context),


### PR DESCRIPTION
When clicked on the "download desktop app" icon on the menu drawer the user will be able to share the download link for the desktop app