### PR TITLE
Remove comma in AltStore/SideStore source.

### DIFF
--- a/ios/app.json
+++ b/ios/app.json
@@ -23,7 +23,7 @@
         "https://github.com/spknetwork/Android-App/releases/download/v1.0.3_48/IMG_5652.PNG",
         "https://github.com/spknetwork/Android-App/releases/download/v1.0.3_48/IMG_5653.PNG",
         "https://github.com/spknetwork/Android-App/releases/download/v1.0.3_48/IMG_5654.PNG",
-        "https://github.com/spknetwork/Android-App/releases/download/v1.0.3_48/IMG_5655.PNG",
+        "https://github.com/spknetwork/Android-App/releases/download/v1.0.3_48/IMG_5655.PNG"
       ],
       "beta": false
     }


### PR DESCRIPTION
This makes it so there is no problem with adding the source to AltStore or sidestore. Having the comma there makes it think there is another line for screenshots.